### PR TITLE
#163684293 Get all offices endpoint

### DIFF
--- a/app/api/controller/office_api.py
+++ b/app/api/controller/office_api.py
@@ -2,7 +2,7 @@
 from flask import request, Blueprint
 from flask.views import MethodView
 
-from app.api.service.office import save_new_office, get_office
+from app.api.service.office import save_new_office, get_office, get_offices
 
 offices = Blueprint('office', __name__)
 
@@ -18,7 +18,7 @@ class OfficeAPI(MethodView):
     def get(self, _id):
         if _id is None:
             # return list of all offices
-            pass
+            return get_offices()
         else:
             # return single offices
             return get_office(_id=_id)
@@ -29,3 +29,4 @@ offices_view = OfficeAPI.as_view('offices')
 # office endpoints rules
 offices.add_url_rule('/offices', view_func=offices_view, methods=["POST"])
 offices.add_url_rule('/offices/<uuid:_id>', view_func=offices_view, methods=["GET"])
+offices.add_url_rule('/offices',defaults={'_id': None}, view_func=offices_view, methods=["GET"])

--- a/app/api/service/office.py
+++ b/app/api/service/office.py
@@ -6,7 +6,7 @@ from flask import jsonify
 
 from app.api.db.mock_db import MockDB
 from app.api.model.office import Office
-from app.api.util.dto import office_schema
+from app.api.util.dto import office_schema, offices_schema
 
 
 def save_new_office(json_data):
@@ -46,6 +46,14 @@ def get_office(_id):
             "status": 404,
             "error": "Resource /offices/{} not found".format(_id)
         }), 404
+
+def get_offices():
+    """Method to get all offices from list"""
+    offices = offices_schema.dump(MockDB.OFFICES)
+    return jsonify({
+        "status": 200,
+        "data": offices,
+    }), 200
 
 def save_changes(data):
     """ Write to the mock db """

--- a/app/tests/test_office_api.py
+++ b/app/tests/test_office_api.py
@@ -52,3 +52,19 @@ class OfficeAPITestCase(BaseTestData):
             'api/v1/offices/{}'.format(_id)
         )
         self.assertEqual(get_response.status_code, 404)
+
+    def test_get_all_offices(self):
+        """
+        Test api can all offices from the OFFICES list.
+        :return: STATUS CODE 200
+        """
+        # do a post first
+        response = self.office_data
+        self.assertEqual(response.status_code, 201)
+        # add another entry
+        response = self.office_data
+        self.assertEqual(response.status_code, 201)
+        get_response = self.client.get(
+            'api/v1/offices'
+        )
+        self.assertEqual(get_response.status_code, 200)


### PR DESCRIPTION
#### What does this PR do?
<!-- A short description of what the pull request does -->
Builds the endpoint to get all offices records.

#### Description of Task to be completed?
<!-- Outline the tasks completed by the pr -->
- [x] Write a test for getting all offices
- [x] Add the endpoint URL rule

#### How should this be manually tested?
After cloning the repository to your local machine - check
[README.md](README.md) for instructions checkout to `ft-get-all-offices-163684293` branch. [Install the requirements](https://github.com/ChegeBryan/politico#installing) and launch the flask server check [here](https://github.com/ChegeBryan/politico#starting-the-server) for instructions. Using [Postman](https://www.getpostman.com/) open create a `POST` request with this header
`Key Content-Type: application/json`.
Put this in the `json` body (example)
```JSON
{
	"officeName": "Senate",
	"officeType": "Congress"
}
```

#### What are the relevant pivotal tracker stories?
[#163684293](https://www.pivotaltracker.com/story/show/163684293)

#### Screenshots
##### `GET /offices`
![screenshot from 2019-02-07 15-44-33](https://user-images.githubusercontent.com/40359451/52412281-54d05300-2aef-11e9-905c-9c1f074ab80a.png)
