### PR TITLE
#163802209 Validate office inputs

### DIFF
--- a/app/api/service/office.py
+++ b/app/api/service/office.py
@@ -3,6 +3,7 @@ Method for data manipulation between controller and models
 in the mock db
 """
 from flask import jsonify
+from marshmallow import ValidationError
 
 from app.api.db.mock_db import MockDB
 from app.api.model.office import Office
@@ -12,7 +13,14 @@ from app.api.util.dto import office_schema, offices_schema
 def save_new_office(json_data):
     """ Method to save new office to list """
     # Deserialize the data input against the office schema
-    data = office_schema.load(json_data)
+    # check for validation errors
+    try:
+        data = office_schema.load(json_data)
+    except ValidationError as e:
+        return jsonify({
+           "status": 400,
+           "error": e.messages
+        }), 400
     officeName = data["officeName"]
     officeType = data["officeType"]
     isOccupied = data["isOccupied"]

--- a/app/api/util/dto.py
+++ b/app/api/util/dto.py
@@ -19,8 +19,10 @@ class OfficeSchema(Schema):
     Office schema mapped onto Office() class attributes
     """
     officeId = fields.UUID()
-    officeName = fields.Str(required=True)
-    officeType = fields.Str(required=True)
+    officeName = fields.Str(required=True, validate=[validate.OneOf(
+        ('president', 'governor', 'senator', 'house of representatives'), error="{input} not a valid office name. Try one of these {choices}.")])
+    officeType = fields.Str(required=True, validate=[validate.OneOf(
+        ('federal', 'congress', 'state'), error="{input} not a valid office type. Try one of these {choices}.")])
     isOccupied = fields.Boolean(missing=False)
 
 

--- a/app/tests/base_test.py
+++ b/app/tests/base_test.py
@@ -35,9 +35,10 @@ class BaseTestData(unittest.TestCase):
             "/api/v1/parties", json=self.party_holder)
 
         # data to use for office test
-        self.office = Office('Senate', 'Congress', False)
+        self.office = Office('senator', 'congress', False)
         self.office_holder = self.office.office_jsonified()
-
+        self.invalid_office_name = Office('sene', "congress", False)
+        self.invalid_office_name_holder = self.invalid_office_name.office_jsonified()
         # office post client
         self.office_data = self.client.post(
             '/api/v1/offices', json=self.office_holder

--- a/app/tests/test_office_api.py
+++ b/app/tests/test_office_api.py
@@ -68,3 +68,29 @@ class OfficeAPITestCase(BaseTestData):
             'api/v1/offices'
         )
         self.assertEqual(get_response.status_code, 200)
+
+    def test_office_entered_is_valid(self):
+        """
+        Test validates if an office name entered is a valid office
+        : STATUS CODE 400
+        """
+        response = self.client.post(
+            '/api/v1/offices', json=self.invalid_office_name_holder
+        )
+        json_body = response.get_json()
+        self.assertEqual(json_body["error"]["officeName"][0],
+                         "sene not a valid office name. Try one of these president, governor, senator, house of representatives.")
+        self.assertEqual(response.status_code, 400)
+
+    def test_office_type_is_valid(self):
+        """
+        Test to check office type entered is a valid office
+        STATUS CODE 400
+        """
+        response = self.client.post(
+            '/api/v1/offices', json=self.invalid_office_type_holder
+        )
+        json_body = response.get_json()
+        self.assertEqual(json_body["error"]["officeType"][0],
+                         "cong not a valid office type. Try one of these federal, congress, state.")
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
#### What does this PR do?
<!-- A short description of what the pull request does -->
Creates validations for office name and type. 
#### Description of Task to be completed?
<!-- Outline the tasks completed by the pr -->
- [x] Write tests for validating data.
- [x] Add validations for the office input.

#### How should this be manually tested?
After cloning the repository to your local machine - check
[README.md](README.md) for instructions checkout to `bg-validate-office-input-163802209` branch. [Install the requirements](https://github.com/ChegeBryan/politico#installing) and launch the flask server check [here](https://github.com/ChegeBryan/politico#starting-the-server) for instructions. Using [Postman](https://www.getpostman.com/) open create a `POST` request with this header
`Key Content-Type: application/json`.
```JSON
{
	"officeName": "any name",
	"officeType": "any thing"
}
```

#### What are the relevant pivotal tracker stories?
[#163802209](https://www.pivotaltracker.com/story/show/163802209)

#### Postman Documentation.
[Postman Docs](https://documenter.getpostman.com/view/4869820/RztoM8mV)

#### Screenshots
##### `POST /offices`
![screenshot from 2019-02-08 07-55-52](https://user-images.githubusercontent.com/40359451/52459585-25652900-2b77-11e9-8f67-a5066e66e69f.png)