### PR TITLE
#164688908 User: Get specific party with id 

### DIFF
--- a/app/api/controller/party_api.py
+++ b/app/api/controller/party_api.py
@@ -43,7 +43,7 @@ parties_view = PartiesAPI.as_view('parties')
 
 # api endpoints rules
 parties.add_url_rule('/parties', view_func=parties_view, methods=["POST"])
-parties.add_url_rule('/parties/<uuid:_id>',
+parties.add_url_rule('/parties/<int:_id>',
                      view_func=parties_view, methods=["GET", "DELETE"])
 parties.add_url_rule('/parties', defaults={'_id': None},
                      view_func=parties_view, methods=["GET"])

--- a/app/api/controller/party_api.py
+++ b/app/api/controller/party_api.py
@@ -3,7 +3,7 @@ from flask.views import MethodView
 
 from app.api.service.party import (
     save_new_party, get_party, get_parties, edit_party, delete_party)
-from app.api.util.decorator import admin_token_required
+from app.api.util.decorator import admin_token_required, token_required
 
 parties = Blueprint('parties', __name__)
 
@@ -19,6 +19,7 @@ class PartiesAPI(MethodView):
         json_input = request.get_json()
         return save_new_party(json_data=json_input)
 
+    @token_required
     def get(self, _id):
         if _id is None:
             # return list of all parties

--- a/app/api/model/party.py
+++ b/app/api/model/party.py
@@ -45,8 +45,17 @@ class Party:
 
     @staticmethod
     def get_party_by_id(identifier):
-        """Method to get a Party in the PARTIES list by its ID"""
-        return get_item(identifier, MockDB.PARTIES)
+        """ SQL query to return a party found in the database
+
+        Args:
+            identifier : party id
+
+        Returns:
+            tuple : select party sql query
+        """
+        sql = """SELECT * FROM parties WHERE id=%s;"""
+        query = sql, (identifier,)
+        return query
 
     @staticmethod
     def update_party(_id, name):

--- a/app/api/service/party.py
+++ b/app/api/service/party.py
@@ -49,8 +49,17 @@ def save_new_party(json_data):
 
 
 def get_party(_id):
-    """Method to display out the party to the get /parties/<uuid:id>"""
-    party = Party.get_party_by_id(_id)
+    """Method to return the party from the database with the provided id
+
+    Args:
+        _id (integer): the party unique identifier
+
+    Returns:
+        1. json : the party found details in json format
+        2. json : error if the party is not found
+    """
+    party_query = Party.get_party_by_id(_id)
+    party = db().get_single_row(*party_query)
     if party:
         # response when party exists
         return jsonify({

--- a/app/tests/test_party_api.py
+++ b/app/tests/test_party_api.py
@@ -222,16 +222,28 @@ class PartyAPITestCase(BaseTestData):
     def test_get_single_party(self):
         """
         Test api can get a specific party with the provided party id
-        from the PARTIES list.
+        from the parties table provided the user is logged in.
         :return: STATUS CODE 200
         """
-        # do a post first
+        # do a post first done by admin user.
         response = self.post_data
         self.assertEqual(response.status_code, 201)
-        json_data = response.get_json()
-        _id = json_data["data"][0]["party_id"]
+
+        # signup normal user
+        user_signup = self.user_data
+        self.assertEqual(user_signup.status_code, 201)
+
+        # signin the user
+        user_signin = self.login_data
+        json_body = user_signin.get_json()
+        auth_token = json_body["data"][0]["token"]
+        self.assertTrue(user_signin.status_code, 200)
+
+        # request party with the user logged in token
         get_response = self.client.get(
-            'api/v1/parties/{}'.format(_id)
+            'api/v2/parties/1', headers={
+                "Authorization": "Bearer {}".format(auth_token)
+            }
         )
         self.assertEqual(get_response.status_code, 200)
 


### PR DESCRIPTION
#### What does this PR do?
<!-- A short description of what the pull request does -->
Refactors the Get party endpoint to allow only logged in users access.
 
#### Description of Task to be completed?
<!-- Outline the tasks completed by the pr -->
- [x] Refactor get party test to include authorization header
- [x] SQL string query to query parties in database 
- [x] change URL variable name converter to integer

#### How should this be manually tested?
After cloning the repository to your local machine - check
[README.md](README.md) for instructions checkout to `ft-user-fetch-party-164688908` branch. [Install the requirements](https://github.com/ChegeBryan/politico#installing) and launch the flask server check [here](https://github.com/ChegeBryan/politico#starting-the-server) for instructions. Using [Postman](https://www.getpostman.com/) create party  [how to create a party](https://github.com/ChegeBryan/politico/pull/45)
After you have successfully created a party you can access the `GET /api/v2/parties/{party_id}` to get the party created. In this request, the `authorization header token` for a signed in user is required.

#### What are the relevant pivotal tracker stories?
[#164688908](https://www.pivotaltracker.com/story/show/164688908)

#### Screenshot
##### Create party as Admin `POST /api/v2/parties`
![Screenshot from 2019-03-24 17-35-27](https://user-images.githubusercontent.com/40359451/54880911-5b2a4c80-4e5b-11e9-9cce-d6aabe399d12.png)

##### Get party `GET /api/v2/parties/{party_id}`
![Screenshot from 2019-03-24 17-38-59](https://user-images.githubusercontent.com/40359451/54880941-c542f180-4e5b-11e9-9f60-391d2d00bb5b.png)