### PR TITLE
#164688904 Admin: delete party 

### DIFF
--- a/app/api/controller/party_api.py
+++ b/app/api/controller/party_api.py
@@ -34,6 +34,7 @@ class PartiesAPI(MethodView):
         json_input = request.get_json()
         return edit_party(_id=_id, json_data=json_input)
 
+    @admin_token_required
     def delete(self, _id):
         # delete a political party
         return delete_party(_id=_id)

--- a/app/api/model/party.py
+++ b/app/api/model/party.py
@@ -84,10 +84,14 @@ class Party:
 
     @staticmethod
     def delete_party(_id):
-        """ Method to delete party from parties list """
-        party = get_item(_id, MockDB.PARTIES)
-        if party:
-            MockDB.PARTIES.remove(party)
-            return True
-        else:
-            return False
+        """ SQL query to delete selected party from the database
+
+        Args:
+            _id : party id
+
+        Returns:
+            tuple : delete party sql query
+        """
+        sql = """DELETE FROM parties WHERE id=%s;"""
+        query = sql, (_id,)
+        return query

--- a/app/api/service/party.py
+++ b/app/api/service/party.py
@@ -133,6 +133,9 @@ def delete_party(_id):
     party_to_delete_query = Party.get_party_by_id(_id)
     party_to_delete = db().get_single_row(*party_to_delete_query)
     if party_to_delete:
+        # delete found party
+        query, value = Party.delete_party(_id)
+        db().commit_changes(query, value)
 
         return jsonify({
             "status": 200,

--- a/app/api/service/party.py
+++ b/app/api/service/party.py
@@ -124,10 +124,16 @@ def edit_party(_id, json_data):
 
 
 def delete_party(_id):
-    """ Method to delete party and return response message """
-    res = Party.delete_party(_id)
-    if res:
-        # response for successful deletion
+    """delete the selected party
+
+    Returns:
+        1. json : response message o details in json format
+    """
+    # check if party to delete exists
+    party_to_delete_query = Party.get_party_by_id(_id)
+    party_to_delete = db().get_single_row(*party_to_delete_query)
+    if party_to_delete:
+
         return jsonify({
             "status": 200,
             "data": [{

--- a/app/tests/test_party_api.py
+++ b/app/tests/test_party_api.py
@@ -366,8 +366,14 @@ class PartyAPITestCase(BaseTestData):
         self.assertEqual(response.status_code, 201)
         json_data = response.get_json()
         _id = json_data["data"][0]["party_id"]
+
+        # get admin token
+        auth_token = self.admin_token
+
         response = self.client.delete(
-            'api/v1/parties/{}'.format(_id)
+            'api/v2/parties/{}'.format(_id), headers={
+                "Authorization": "Bearer {}".format(auth_token)
+            }
         )
         res = response.get_json()
         self.assertEqual(res["data"][0]["message"],

--- a/app/tests/test_party_api.py
+++ b/app/tests/test_party_api.py
@@ -385,9 +385,15 @@ class PartyAPITestCase(BaseTestData):
         Test error message for for non existing party deletion.
         :return: STATUS CODE 404
         """
-        _id = uuid.uuid4()
+        _id = 233  # random id
+
+        #admin token
+        auth_token = self.admin_token
+
         response = self.client.delete(
-            'api/v1/parties/{}'.format(_id)
+            'api/v2/parties/{}'.format(_id), headers={
+                "Authorization": "Bearer {}".format(auth_token)
+            }
         )
         res = response.get_json()
         self.assertEqual(res["data"][0]["message"],


### PR DESCRIPTION
#### What does this PR do?
<!-- A short description of what the pull request does -->
Builds the v2 of the delete party route

#### Description of Task to be completed?
<!-- Outline the tasks completed by the pr -->
- [x] Refactor delete party with authorization
- [x] Add SQL query to delete a party from the database 

#### How should this be manually tested?
After cloning the repository to your local machine - check
[README.md](README.md) for instructions checkout to `ft-admin-delete-party-164688904` branch. [Install the requirements](https://github.com/ChegeBryan/politico#installing) and launch the flask server check [here](https://github.com/ChegeBryan/politico#starting-the-server) for instructions. Using [Postman](https://www.getpostman.com/) open create a request with this header to signin an admin user (NB: This is the default admin user).
HEADER:
`Key Content-Type: application/json`.

Put this in the `json` body
```json
{
    "email": "admin@politico.org",
    "password": "2019NBO37"
}
```
Once the admin user is signed in. Copy the auth token in the response body. This will be used in the next request. Create a delete party request `DELETE /api/v2/parties/{party_id}` with the following headers:
`Key Content-Type: application/json`.
```JSON
Authorization header Bearer token = copied auth token
```

#### What are the relevant pivotal tracker stories?
[#164688904](https://www.pivotaltracker.com/story/show/164688904)

#### Screenshots (if appropriate)
##### Admin: delete party `DELETE /api/v2/parties/{party_id}`
![Screenshot from 2019-03-25 23-11-46](https://user-images.githubusercontent.com/40359451/54950897-68c2fd80-4f53-11e9-916b-599872af3b50.png)
