### PR TITLE
#164980891 Fixes IntegrityError response

### DIFF
--- a/app/api/service/candidate.py
+++ b/app/api/service/candidate.py
@@ -49,10 +49,13 @@ def save_new_candidate(office_id, json_data):
         try:
             save_changes(_id=office_id, data=new_candidate)
         except IntegrityError:
+            # json when integrityError in the database is raised caused by
+            # foreign key referencing
             response_object = jsonify({
                 "status": 409,
-                "error": "Data conflict encountered"
+                "error": "Party, office or user referenced does not exists."
             })
+            return response_object, 409
     else:
         response_object = jsonify({
             "status": 409,

--- a/app/api/util/dto.py
+++ b/app/api/util/dto.py
@@ -131,7 +131,7 @@ class CandidateSchemaDump(BaseSchema):
     candidate = fields.Integer(attribute='candidate_id')
     office = fields.Integer(attribute='office_id')
     party = fields.Integer(attribute='party_id')
-    registered_on = fields.DateTime(attribute='created_on')
+    registered_on = fields.LocalDateTime(attribute='created_on')
 
 
 party_schema = PartySchema()

--- a/app/tests/test_candidate_api.py
+++ b/app/tests/test_candidate_api.py
@@ -277,3 +277,40 @@ class CandidateAPITestCases(BaseTestData):
         self.assertEqual(json_data["error"],
                          "Party or user exists under an office.")
         self.assertEqual(res_reg_same_user.status_code, 409)
+
+    def test_user_referenced(self):
+        """
+        Test api returns correct error code and response message on attempt to
+        register a candidate that does not exist for office
+        : return STATUS CODE 409 Conflict
+        """
+
+        # get token of signed in admin user
+        auth_token = self.admin_token
+
+        # create another party which will have an id of 2
+        response_party = self.client.post(
+            '/api/v2/parties', json=party_2,
+            headers={
+                "Authorization": "Bearer {}".format(auth_token)
+            }
+        )
+        self.assertEqual(response_party.status_code, 201)
+
+        # register non existing candidate for an office
+        # candatate with a an id 3 does not exist
+        response_office = self.client.post(
+            '/api/v2/office/1/register',
+            json={
+                "party": 2,
+                "candidate": 3
+            },
+            headers={
+                "Authorization": "Bearer {}".format(auth_token)
+            }
+        )
+        json_data = response_office.get_json()
+        self.assertEqual(json_data["status"], 409)
+        self.assertEqual(json_data["error"],
+                         "Party, office or user referenced does not exists.")
+        self.assertEqual(response_office.status_code, 409)

--- a/app/tests/test_candidate_api.py
+++ b/app/tests/test_candidate_api.py
@@ -332,10 +332,45 @@ class CandidateAPITestCases(BaseTestData):
         # get token of signed in admin user
         auth_token = self.admin_token
 
-        # register non existing office for an office
+        # register non existing party for an office
         # party with a an id 2 does not exist
         response_office = self.client.post(
             '/api/v2/office/1/register',
+            json={
+                "party": 2,
+                "candidate": 3
+            },
+            headers={
+                "Authorization": "Bearer {}".format(auth_token)
+            }
+        )
+        json_data = response_office.get_json()
+        self.assertEqual(json_data["status"], 409)
+        self.assertEqual(json_data["error"],
+                         "Party, office or user referenced does not exists.")
+        self.assertEqual(response_office.status_code, 409)
+
+    def test_office_referenced(self):
+        """
+        Test api returns correct error code and response message on attempt to
+        register a candidate on a non exist office
+        : return STATUS CODE 409 Conflict
+        """
+
+        # register a new user whose id now becomes 3 on account the admin user
+        # was registered before therefore user_2 has an id of 3
+        res_signup_user = self.client.post(
+            '/api/v2/auth/signup', json=user_2
+        )
+        self.assertEqual(res_signup_user.status_code, 201)
+
+        # get token of signed in admin user
+        auth_token = self.admin_token
+
+        # register non existing office for an office
+        # party with a an id 2 does not exist
+        response_office = self.client.post(
+            '/api/v2/office/67/register',
             json={
                 "party": 2,
                 "candidate": 3

--- a/app/tests/test_candidate_api.py
+++ b/app/tests/test_candidate_api.py
@@ -314,3 +314,38 @@ class CandidateAPITestCases(BaseTestData):
         self.assertEqual(json_data["error"],
                          "Party, office or user referenced does not exists.")
         self.assertEqual(response_office.status_code, 409)
+
+    def test_party_referenced(self):
+        """
+        Test api returns correct error code and response message on attempt to
+        register a party that does not exist for office
+        : return STATUS CODE 409 Conflict
+        """
+
+        # register a new user whose id now becomes 3 on account the admin user
+        # was registered before therefore user_2 has an id of 3
+        res_signup_user = self.client.post(
+            '/api/v2/auth/signup', json=user_2
+        )
+        self.assertEqual(res_signup_user.status_code, 201)
+
+        # get token of signed in admin user
+        auth_token = self.admin_token
+
+        # register non existing office for an office
+        # party with a an id 2 does not exist
+        response_office = self.client.post(
+            '/api/v2/office/1/register',
+            json={
+                "party": 2,
+                "candidate": 3
+            },
+            headers={
+                "Authorization": "Bearer {}".format(auth_token)
+            }
+        )
+        json_data = response_office.get_json()
+        self.assertEqual(json_data["status"], 409)
+        self.assertEqual(json_data["error"],
+                         "Party, office or user referenced does not exists.")
+        self.assertEqual(response_office.status_code, 409)

--- a/app/tests/test_party_model.py
+++ b/app/tests/test_party_model.py
@@ -4,7 +4,6 @@ import unittest
 
 
 from app.api.model.party import Party
-from app.api.service.party import save_changes
 
 
 class TestPartyModel(unittest.TestCase):


### PR DESCRIPTION
#### What does this PR do?
<!-- A short description of what the pull request does -->
Fixes database IntegrityError raised during candidate registration response

#### Description of Task to be completed?
<!-- Outline the tasks completed by the pr -->
- [x] Add tests for referential error on a party, user and office
- [x] Add appropriate JSON response on IntegrityError encountered
- [x] Update candidate dump schema to output local time

#### How should this be manually tested?
After cloning the repository to your local machine - check
[README.md](README.md) for instructions. Using
[Postman](https://www.getpostman.com/) open a request `POST /api/v2/office/3/register` with this 
headers:
`Key Authorization: Bearer admin_token`
`Key Content-Type: application/json`

JSON body example (totally random values):
```JSON
{
	"party": 34,
	"candidate": 235
}
```
#### What are the relevant pivotal tracker stories?
[#164980891](https://www.pivotaltracker.com/story/show/164980891)

#### Screenshots
##### `POST /api/v2/office/{office_id}/register`
![Screenshot from 2019-03-29 13-51-49](https://user-images.githubusercontent.com/40359451/55227961-df991880-5229-11e9-86f3-762215609ccd.png)
