### PR TITLE
#166120924 Fixes user schema field names inconsistency

### DIFF
--- a/app/api/util/dto.py
+++ b/app/api/util/dto.py
@@ -115,9 +115,13 @@ class UserSchema(BaseSchema):
                 min=10,
                 error="{input} is not a valid phonename.")])
     password = fields.String(required=True)
-    passportUrl = fields.Url(required=True)
-    isAdmin = fields.Boolean(missing=False)
-    isPolitician = fields.Boolean(missing=False)
+    passporturl = fields.Url(required=True, data_key='passportUrl',
+                             attribute='passportUrl')
+    isadmin = fields.Boolean(missing=False,
+                             data_key='isAdmin', attribute='isAdmin')
+    ispolitician = fields.Boolean(missing=False,
+                                  data_key='isPolitician',
+                                  attribute='isPolitician')
 
 
 class AuthSchema(BaseSchema):


### PR DESCRIPTION
#### What does this PR do?
<!-- A short description of what the pull request does -->
Specifies the field names to get data for the `passportUrl`, `isAdmin`, `isPolitician` fields during deserialization and serialization of the user schema.

#### Description of Task to be completed?
<!-- Outline the tasks completed by the pr -->
- [x] Add the data_key and attribute parameter.
- [x] Run the tests

#### What are the relevant pivotal tracker stories?
[#166120924](https://www.pivotaltracker.com/story/show/166120924)